### PR TITLE
Remove local roles setter event handler.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 1.7.0 (unreleased)
 ------------------
 
+- Remove local roles setter event handler.
+  This is event handler is no longer necessary.
+  Workflows should set the delegate roles permissions properly.
+  [jone]
+
 - Plone 4.3 compatibility.
   [jone]
 

--- a/ftw/workspace/configure.zcml
+++ b/ftw/workspace/configure.zcml
@@ -40,8 +40,6 @@
         <include package=".latex" />
     </configure>
 
-    <subscriber handler=".content.workspace.workspace_added" />
-
     <utility component=".vocabularies.AssignableUsersVocabularyFactory"
              name="assignable_users"
              provides="zope.schema.interfaces.IVocabularyFactory"

--- a/ftw/workspace/content/workspace.py
+++ b/ftw/workspace/content/workspace.py
@@ -7,10 +7,7 @@ from ftw.workspace.config import PROJECTNAME
 from ftw.workspace.content.schemata import finalizeWorkspaceSchema
 from ftw.workspace.interfaces import IWorkspace
 from Products.Archetypes import atapi
-from Products.Archetypes.interfaces import IObjectInitializedEvent
 from Products.ATContentTypes.content import folder
-from Products.CMFCore.utils import getToolByName
-from zope.component import adapter
 from zope.interface import implements
 from ftw.workspace.utils import TinyMCEAllowedButtonsConfigurator
 
@@ -38,24 +35,6 @@ WorkspaceSchema = folder.ATFolderSchema.copy() + atapi.Schema((
 finalizeWorkspaceSchema(WorkspaceSchema,
                         folderish=True,
                         moveDiscussion=False)
-
-
-@adapter(IWorkspace, IObjectInitializedEvent)
-def workspace_added(object_, event):
-    """When a workspace is created, we add additional local roles
-    to enable the creator to delegate them.
-
-    TODO: Check if this is still necessary.
-    """
-    pm_tool = getToolByName(object_, 'portal_membership')
-    current_user = pm_tool.getAuthenticatedMember().getId()
-    # Fix (PHa): Only set local roles for logged-in user,
-    # if his/her id already has local roles
-    if current_user in object_.__ac_local_roles__:
-        object_.__ac_local_roles__[current_user] += ['Contributor',
-                                                    'Editor',
-                                                    'Reader',
-                                                    'Administrator']
 
 
 class Workspace(folder.ATFolder):


### PR DESCRIPTION
This is event handler is no longer necessary.
Workflows should set the delegate roles permissions properly.

@maethu could you take a look?
