### PR TITLE
Make auto-roles, granted to the owner of a workspace, configurable.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,9 +5,7 @@ Changelog
 1.7.0 (unreleased)
 ------------------
 
-- Remove local roles setter event handler.
-  This is event handler is no longer necessary.
-  Workflows should set the delegate roles permissions properly.
+- Make auto-roles, granted to the owner of a workspace, configurable.
   [jone]
 
 - Plone 4.3 compatibility.

--- a/ftw/workspace/configure.zcml
+++ b/ftw/workspace/configure.zcml
@@ -40,6 +40,8 @@
         <include package=".latex" />
     </configure>
 
+    <subscriber handler=".content.workspace.workspace_added" />
+
     <utility component=".vocabularies.AssignableUsersVocabularyFactory"
              name="assignable_users"
              provides="zope.schema.interfaces.IVocabularyFactory"

--- a/ftw/workspace/content/workspace.py
+++ b/ftw/workspace/content/workspace.py
@@ -2,14 +2,19 @@
 """
 
 from AccessControl import ClassSecurityInfo
+from Products.ATContentTypes.content import folder
+from Products.Archetypes import atapi
+from Products.Archetypes.interfaces import IObjectInitializedEvent
+from Products.CMFCore.utils import getToolByName
 from ftw.workspace import _
 from ftw.workspace.config import PROJECTNAME
 from ftw.workspace.content.schemata import finalizeWorkspaceSchema
 from ftw.workspace.interfaces import IWorkspace
-from Products.Archetypes import atapi
-from Products.ATContentTypes.content import folder
-from zope.interface import implements
 from ftw.workspace.utils import TinyMCEAllowedButtonsConfigurator
+from plone.registry.interfaces import IRegistry
+from zope.component import adapter
+from zope.component import getUtility
+from zope.interface import implements
 
 
 WorkspaceSchema = folder.ATFolderSchema.copy() + atapi.Schema((
@@ -35,6 +40,21 @@ WorkspaceSchema = folder.ATFolderSchema.copy() + atapi.Schema((
 finalizeWorkspaceSchema(WorkspaceSchema,
                         folderish=True,
                         moveDiscussion=False)
+
+
+@adapter(IWorkspace, IObjectInitializedEvent)
+def workspace_added(object_, event):
+    """When a workspace is created, we add additional local roles
+    to enable the creator to delegate them.
+    """
+    pm_tool = getToolByName(object_, 'portal_membership')
+    current_user = pm_tool.getAuthenticatedMember().getId()
+    # Fix (PHa): Only set local roles for logged-in user,
+    # if his/her id already has local roles
+    if current_user in object_.__ac_local_roles__:
+        registry = getUtility(IRegistry)
+        roles = registry['ftw.workspace.auto_roles']
+        object_.__ac_local_roles__[current_user] += roles
 
 
 class Workspace(folder.ATFolder):

--- a/ftw/workspace/profiles/default/metadata.xml
+++ b/ftw/workspace/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1700</version>
+  <version>1701</version>
   <dependencies>
     <dependency>profile-ftw.tabbedview:default</dependency>
     <dependency>profile-ftw.calendar:default</dependency>

--- a/ftw/workspace/profiles/default/registry.xml
+++ b/ftw/workspace/profiles/default/registry.xml
@@ -23,4 +23,17 @@
         </field>
         <value>False</value>
     </record>
+
+    <record name="ftw.workspace.auto_roles">
+        <field type="plone.registry.field.List">
+            <title>Automatically set roles on workspaces</title>
+            <description>Roles automatically given to owners of workspaces upon creation</description>
+            <value_type type="plone.registry.field.TextLine" />
+        </field>
+        <value>
+            <element>Contributor</element>
+            <element>Editor</element>
+            <element>Reader</element>
+        </value>
+    </record>
 </registry>

--- a/ftw/workspace/tests/test_auto_roles.py
+++ b/ftw/workspace/tests/test_auto_roles.py
@@ -1,0 +1,41 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.workspace.testing import FTW_WORKSPACE_INTEGRATION_TESTING
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
+from plone.app.testing import login
+from plone.app.testing import setRoles
+from plone.registry.interfaces import IRegistry
+from unittest2 import TestCase
+from zope.component import getUtility
+
+
+class TestAutoRoles(TestCase):
+
+    layer = FTW_WORKSPACE_INTEGRATION_TESTING
+
+    def setUp(self):
+        portal = self.layer['portal']
+        setRoles(portal, TEST_USER_ID, ['Manager'])
+        login(portal, TEST_USER_NAME)
+
+    def test_roles_are_automaticall_assigned_on_workspace_creation(self):
+        workspace = create(Builder('workspace'))
+        roles = set(dict(workspace.get_local_roles()).get(TEST_USER_ID))
+
+        self.assertEquals(
+            set(['Owner', 'Contributor', 'Editor', 'Reader']),
+            roles,
+            'The configured roles should be automatically granted to the owner.')
+
+    def test_auto_roles_are_configurable_with_registry_entry(self):
+        registry = getUtility(IRegistry)
+        roles = registry['ftw.workspace.auto_roles'] = [u'Editor']
+
+        workspace = create(Builder('workspace'))
+        roles = set(dict(workspace.get_local_roles()).get(TEST_USER_ID))
+
+        self.assertEquals(
+            set(['Owner', 'Editor']),
+            roles,
+            'Only the configured auto_roles should be granted to the owner.')

--- a/ftw/workspace/upgrades/configure.zcml
+++ b/ftw/workspace/upgrades/configure.zcml
@@ -60,5 +60,24 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
+    <!-- 1700 -> 1701 -->
+    <genericsetup:upgradeStep
+        title="Install new auto-role configuration setting"
+        description=""
+        source="1700"
+        destination="1701"
+        handler="ftw.workspace.upgrades.to1701.ImportRegistry"
+        profile="ftw.workspace:default"
+        />
+
+    <genericsetup:registerProfile
+        name="1701"
+        title="ftw.workspace.upgrades.1701"
+        description=""
+        directory="profiles/1701"
+        for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
 
 </configure>

--- a/ftw/workspace/upgrades/profiles/1701/registry.xml
+++ b/ftw/workspace/upgrades/profiles/1701/registry.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<registry>
+    <record name="ftw.workspace.auto_roles">
+        <field type="plone.registry.field.List">
+            <title>Automatically set roles on workspaces</title>
+            <description>Roles automatically given to owners of workspaces upon creation</description>
+            <value_type type="plone.registry.field.TextLine" />
+        </field>
+        <value>
+            <element>Contributor</element>
+            <element>Editor</element>
+            <element>Reader</element>
+        </value>
+    </record>
+</registry>

--- a/ftw/workspace/upgrades/to1701.py
+++ b/ftw/workspace/upgrades/to1701.py
@@ -1,0 +1,7 @@
+from ftw.upgrade import UpgradeStep
+
+
+class ImportRegistry(UpgradeStep):
+
+    def __call__(self):
+        self.setup_install_profile('profile-ftw.workspace.upgrades:1701')


### PR DESCRIPTION
@maethu we can not drop the auto roles, but we can make it configurable.
