### PR TITLE
Use human date formatting with "today", "yesterday" etc.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use human date formatting with "today", "yesterday" etc.
+  for tabs "documents", "events" and "workspaces".
+  [jone]
 
 
 1.7.0 (2013-08-28)

--- a/ftw/workspace/browser/documents.py
+++ b/ftw/workspace/browser/documents.py
@@ -32,7 +32,7 @@ class DocumentsTab(Tab):
         # default implementation
         date_column = {'column': 'effective',
                        'column_title': _(u'column_date', default=u'date'),
-                       'transform': helper.readable_date,
+                       'transform': helper.readable_date_text,
                        'width': 100}
         # ftw.file implementation
         if has_ftwfile(self.context):
@@ -59,7 +59,7 @@ class DocumentsTab(Tab):
 
             {'column': 'modified',
              'column_title': _(u'column_modified', default=u'modified'),
-             'transform': helper.readable_date,
+             'transform': helper.readable_date_text,
              'width': 80},
         )
         return columns

--- a/ftw/workspace/browser/events.py
+++ b/ftw/workspace/browser/events.py
@@ -22,7 +22,7 @@ class EventsTab(listing.CatalogListingView):
     columns = ({'column': 'start',
                 'column_index': 'start',
                 'column_title': _(u'label_eventstab_start'),
-                'transform': helper.readable_date,
+                'transform': helper.readable_date_text,
                 'width': 80},
 
                {'column': 'Title',

--- a/ftw/workspace/browser/workspaces.py
+++ b/ftw/workspace/browser/workspaces.py
@@ -29,7 +29,7 @@ class WorkspacesTab(Tab):
 
         {'column': 'modified',
          'column_title': _(u'column_modified', default=u'modified'),
-         'transform': helper.readable_date,
+         'transform': helper.readable_date_text,
          'width': 80},
 
         {'column': 'Creator',


### PR DESCRIPTION
For tabs "documents", "events" and "workspaces".
@maethu :apple: 
