### PR TITLE
The preview image should not be bigger than the container.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- The preview image should not be bigger than the container.
+  [Julian Infanger]
 
 
 2.0.0 (2013-11-04)

--- a/ftw/workspace/browser/resources/preview.css
+++ b/ftw/workspace/browser/resources/preview.css
@@ -7,6 +7,11 @@
   position: relative;
   box-shadow: 4px 4px 10px #d3d3d3;
   text-align: center;
+  overflow: hidden;
+}
+.previewContainer img {
+  max-width: 100%;
+  max-height: 100%;
 }
 
 .previewTitle {


### PR DESCRIPTION
![bildschirmfoto-2013-11-05-um-11 38 07](https://f.cloud.github.com/assets/157533/1472670/3ec06c58-4607-11e3-9361-d8aa8f8af3c8.png)
@maethu 
