### PR TITLE
Implement a more robust quick_upload id generator.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix quick_upload id generator (allow filenames staring with an '_')
+  [mathias.leimgruber]
 
 
 2.0.2 (2013-11-28)

--- a/ftw/workspace/quick_upload.py
+++ b/ftw/workspace/quick_upload.py
@@ -17,7 +17,6 @@ def generate_id(name, context):
     chooser = INameChooser(context)
 
     normalized = normalizer.normalize(name)
-    # Replace '_', because chooseName cannot handle names staring with '_'
     normalized = normalized.replace('_', '-').replace(' ', '-').lower()
 
     return chooser.chooseName(normalized, context)
@@ -48,7 +47,8 @@ class WorkspaceQuickUploadCapableFileFactory(object):
         if portal_type not in upload_addable and upload_addable:
             portal_type = upload_addable[0]
 
-        newid = title = generate_id(name, self.context)
+        newid = generate_id(name, self.context)
+        title = name
 
         # copied from collective.quickupload
         upload_lock.acquire()

--- a/ftw/workspace/tests/test_id_generator.py
+++ b/ftw/workspace/tests/test_id_generator.py
@@ -1,0 +1,39 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.workspace.quick_upload import generate_id
+from ftw.workspace.testing import FTW_WORKSPACE_INTEGRATION_TESTING
+from plone.app.testing import login
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
+from unittest2 import TestCase
+
+
+class TestQuickUploadIdGenerator(TestCase):
+
+    layer = FTW_WORKSPACE_INTEGRATION_TESTING
+
+    def setUp(self):
+        super(TestQuickUploadIdGenerator, self).setUp()
+
+        self.portal = self.layer['portal']
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+        login(self.portal, TEST_USER_NAME)
+
+    def test_name_starting_with_underscore(self):
+        name = u'_test'
+        self.assertEquals(u'test', generate_id(name, self.portal))
+
+    def test_existing_name(self):
+        create(Builder('file').titled('test'))
+        name = u'test'
+        self.assertEquals(u'test-1', generate_id(name, self.portal))
+
+    def test_name_with_umlauts(self):
+        create(Builder('file').titled('test'))
+        name = u't\xf6st'
+        self.assertEquals(u'tost', generate_id(name, self.portal))
+
+    def test_name_with_spaces(self):
+        name = u'test test'
+        self.assertEquals(u'test-test', generate_id(name, self.portal))

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ import os
 version = '2.0.3.dev0'
 
 tests_require = [
+    'collective.quickupload',
     'plone.app.testing',
     'ftw.file',
     'ftw.testing',


### PR DESCRIPTION
Files starting with '_' did not work before. 
