### PR TITLE
Quick upload factory: also reindex dexterity types.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.0.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Quick upload factory: also reindex dexterity types.
+  [jone]
 
 
 2.0.4 (2014-02-05)

--- a/ftw/workspace/quick_upload.py
+++ b/ftw/workspace/quick_upload.py
@@ -1,4 +1,5 @@
 from AccessControl import Unauthorized
+from Products.CMFPlone.utils import base_hasattr
 from Acquisition import aq_inner
 from ZODB.POSException import ConflictError
 from collective.quickupload import logger
@@ -81,7 +82,12 @@ class WorkspaceQuickUploadCapableFileFactory(object):
                     error = IQuickUploadFileSetter(obj).set(
                         data, filename, content_type)
 
-                obj.processForm()
+                if base_hasattr(obj, 'processForm'):
+                    # AT: includes reindexing the object.
+                    obj.processForm()
+                else:
+                    # Dexterity
+                    obj.reindexObject()
 
             #@TODO : rollback if there has been an error
             transaction.commit()


### PR DESCRIPTION
The quick upload factory currently executes `processForm` (from Archetypes) on newly created file objects.
When creating dexterity types (such as `ftw.mail`), `processForm` is executed on the acquision parent, since dexterity has no `processForm`.

This PR changes to this behavior to check whether we have `processForm` (AT) and fall back to a direct `reindexObject` when it is missing (DX).

@maethu can you take a look at this one?
