### PR TITLE
Hide upload option of text field on Workspace content.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2.1.1 (unreleased)
 ------------------
 
+- Hide upload option of text field on Workspace and TabbedViewFolder.
+  [mathias.leimgruber]
+
 - Use ftw.builder ImageBuilder, remove the ImageBuilder of this package.
   [mathias.leimgruber]
 

--- a/ftw/workspace/content/folder_extender.py
+++ b/ftw/workspace/content/folder_extender.py
@@ -31,6 +31,7 @@ class FolderExtender(object):
         widget=RichWidget(
             label=_(u"label_text", default=u"Text"),
             rows=15,
+            allow_file_upload=False,
             allow_buttons=TinyMCEAllowedButtonsConfigurator(), )), ]
 
     def __init__(self, context):

--- a/ftw/workspace/content/workspace.py
+++ b/ftw/workspace/content/workspace.py
@@ -31,6 +31,7 @@ WorkspaceSchema = folder.ATFolderSchema.copy() + atapi.Schema((
         widget=atapi.RichWidget(
             label=_(u"label_text", default=u"Text"),
             rows=15,
+            allow_file_upload=False,
             allow_buttons=TinyMCEAllowedButtonsConfigurator(),
         ),
     ),


### PR DESCRIPTION
@jone 
The users upload everything, but no text, nor html files- :smile: 
So I guess the best solution is to hide the upload field.
