### PR TITLE
Cherry-Pick #56 from 4teamwork/mba-filter-by-creator

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -35,7 +35,7 @@ Bootstraps a buildout-based project.
 Simply run this script in a directory containing a buildout.cfg, using the
 Python that you want bin/buildout to use.
 
-Note that by using --find-links to point to local resources, you can keep 
+Note that by using --find-links to point to local resources, you can keep
 this script from going over the network.
 '''
 
@@ -56,6 +56,11 @@ parser.add_option("-c", "--config-file",
                         "file to be used."))
 parser.add_option("-f", "--find-links",
                   help=("Specify a URL to search for buildout releases"))
+parser.add_option("--allow-site-packages",
+                  action="store_true", default=False,
+                  help=("Let bootstrap.py use existing site packages"))
+parser.add_option("--setuptools-version",
+                  help="use a specific setuptools version")
 
 
 options, args = parser.parse_args()
@@ -63,32 +68,42 @@ options, args = parser.parse_args()
 ######################################################################
 # load/install setuptools
 
-to_reload = False
 try:
-    import pkg_resources
-    import setuptools
+    if options.allow_site_packages:
+        import setuptools
+        import pkg_resources
+    from urllib.request import urlopen
 except ImportError:
-    ez = {}
+    from urllib2 import urlopen
 
-    try:
-        from urllib.request import urlopen
-    except ImportError:
-        from urllib2 import urlopen
+ez = {}
+exec(urlopen('https://bootstrap.pypa.io/ez_setup.py').read(), ez)
 
-    # XXX use a more permanent ez_setup.py URL when available.
-    exec(urlopen('https://bitbucket.org/pypa/setuptools/raw/0.7.2/ez_setup.py'
-                ).read(), ez)
-    setup_args = dict(to_dir=tmpeggs, download_delay=0)
-    ez['use_setuptools'](**setup_args)
+if not options.allow_site_packages:
+    # ez_setup imports site, which adds site packages
+    # this will remove them from the path to ensure that incompatible versions
+    # of setuptools are not in the path
+    import site
+    # inside a virtualenv, there is no 'getsitepackages'.
+    # We can't remove these reliably
+    if hasattr(site, 'getsitepackages'):
+        for sitepackage_path in site.getsitepackages():
+            sys.path[:] = [x for x in sys.path if sitepackage_path not in x]
 
-    if to_reload:
-        reload(pkg_resources)
-    import pkg_resources
-    # This does not (always?) update the default working set.  We will
-    # do it.
-    for path in sys.path:
-        if path not in pkg_resources.working_set.entries:
-            pkg_resources.working_set.add_entry(path)
+setup_args = dict(to_dir=tmpeggs, download_delay=0)
+
+if options.setuptools_version is not None:
+    setup_args['version'] = options.setuptools_version
+
+ez['use_setuptools'](**setup_args)
+import setuptools
+import pkg_resources
+
+# This does not (always?) update the default working set.  We will
+# do it.
+for path in sys.path:
+    if path not in pkg_resources.working_set.entries:
+        pkg_resources.working_set.add_entry(path)
 
 ######################################################################
 # Install buildout
@@ -119,10 +134,15 @@ if version is None and not options.accept_buildout_test_releases:
     _final_parts = '*final-', '*final'
 
     def _final_version(parsed_version):
-        for part in parsed_version:
-            if (part[:1] == '*') and (part not in _final_parts):
-                return False
-        return True
+        try:
+            return not parsed_version.is_prerelease
+        except AttributeError:
+            # Older setuptools
+            for part in parsed_version:
+                if (part[:1] == '*') and (part not in _final_parts):
+                    return False
+            return True
+
     index = setuptools.package_index.PackageIndex(
         search_path=[setuptools_path])
     if find_links:
@@ -149,8 +169,7 @@ cmd.append(requirement)
 import subprocess
 if subprocess.call(cmd, env=dict(os.environ, PYTHONPATH=setuptools_path)) != 0:
     raise Exception(
-        "Failed to execute command:\n%s",
-        repr(cmd)[1:-1])
+        "Failed to execute command:\n%s" % repr(cmd)[1:-1])
 
 ######################################################################
 # Import and run buildout

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,10 @@ Changelog
 2.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add the fullname of the creator of a workspace to the searchable text
+  index. This way the list of workspaces on the overview tab can be filtered
+  by creator.
+  [mbaechtold]
 
 
 2.2.1 (2014-09-03)

--- a/ftw/workspace/content/workspace.py
+++ b/ftw/workspace/content/workspace.py
@@ -10,6 +10,7 @@ from ftw.workspace import _
 from ftw.workspace.config import PROJECTNAME
 from ftw.workspace.content.schemata import finalizeWorkspaceSchema
 from ftw.workspace.interfaces import IWorkspace
+from ftw.workspace.utils import get_creator_fullname
 from ftw.workspace.utils import TinyMCEAllowedButtonsConfigurator
 from plone.registry.interfaces import IRegistry
 from zope.component import adapter
@@ -70,5 +71,10 @@ class Workspace(folder.ATFolder):
     security.declarePublic('canSetDefaultPage')
     def canSetDefaultPage(self):
         return False
+
+    security.declarePublic('SearchableText')
+    def SearchableText(self):
+        fullname = get_creator_fullname(self)
+        return ' '.join((super(Workspace, self).SearchableText(), fullname))
 
 atapi.registerType(Workspace, PROJECTNAME)

--- a/ftw/workspace/indexers.py
+++ b/ftw/workspace/indexers.py
@@ -1,6 +1,6 @@
-from plone.indexer.decorator import indexer
-from Products.CMFCore.utils import getToolByName
 from ftw.workspace.interfaces import IWorkspace
+from ftw.workspace.utils import get_creator_fullname
+from plone.indexer.decorator import indexer
 from Products.ATContentTypes.interfaces.interfaces import IATContentType
 
 
@@ -13,12 +13,4 @@ def ownerid(object_, **kw):
 
 @indexer(IATContentType)
 def sortable_creator(object_, **kw):
-    creator = object_.Creator()
-    pas_tool = getToolByName(object_, 'acl_users')
-    user = pas_tool.getUserById(creator)
-    if not user:
-        return creator
-    fullname = user.getProperty('fullname', creator)
-    if fullname:
-        return fullname
-    return creator
+    return get_creator_fullname(object_)

--- a/ftw/workspace/profiles/default/metadata.xml
+++ b/ftw/workspace/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1707</version>
+  <version>1708</version>
   <dependencies>
     <dependency>profile-ftw.tabbedview:default</dependency>
     <dependency>profile-ftw.calendar:default</dependency>

--- a/ftw/workspace/tests/test_workspace.py
+++ b/ftw/workspace/tests/test_workspace.py
@@ -1,0 +1,43 @@
+from Products.CMFCore.utils import getToolByName
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.workspace.testing import FTW_WORKSPACE_INTEGRATION_TESTING
+from plone.app.testing import login
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from unittest2 import TestCase
+
+
+class TestWorkspace(TestCase):
+
+    layer = FTW_WORKSPACE_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+
+    def test_searchable_text_contains_workspace_creator(self):
+        """
+        The full name of the creator of a workspace has to be in the
+        searchable text index so the workspace overview listing can
+        be filtered by creator.
+        """
+        folder = create(Builder('folder'))
+        hugo = create(
+            Builder('user')
+            .named('Hugo', 'Boss')
+            .with_roles('Contributor', on=folder)
+        )
+
+        login(self.portal, hugo.getId())
+        workspace = create(
+            Builder('workspace').within(folder).titled('My Workspace')
+        )
+
+        portal_catalog = getToolByName(self.layer['portal'], 'portal_catalog')
+        rid = portal_catalog.getrid('/'.join(workspace.getPhysicalPath()))
+        index_data = portal_catalog.getIndexDataForRID(rid)
+
+        expected = {'boss', 'hugo', 'my', 'workspace'}
+        actual = set(index_data['SearchableText'])
+        self.assertTrue(expected.issubset(actual))

--- a/ftw/workspace/upgrades/configure.zcml
+++ b/ftw/workspace/upgrades/configure.zcml
@@ -157,4 +157,13 @@
         profile="ftw.workspace:default"
         />
 
+    <!-- 1707 -> 1708 -->
+    <genericsetup:upgradeStep
+        title="Add the fullname of the workspace creators to the searchable text index."
+        source="1707"
+        destination="1708"
+        handler=".to1708.IndexWorkspaceCreator"
+        profile="ftw.workspace:default"
+        />
+
 </configure>

--- a/ftw/workspace/upgrades/to1708.py
+++ b/ftw/workspace/upgrades/to1708.py
@@ -1,0 +1,12 @@
+from ftw.upgrade import UpgradeStep
+from ftw.workspace.interfaces import IWorkspace
+import logging
+
+LOG = logging.getLogger('ftw.workspace.upgrades')
+
+
+class IndexWorkspaceCreator(UpgradeStep):
+
+    def __call__(self):
+        query = {'object_provides': IWorkspace.__identifier__}
+        self.catalog_reindex_objects(query, idxs=['SearchableText'])

--- a/ftw/workspace/utils.py
+++ b/ftw/workspace/utils.py
@@ -76,3 +76,15 @@ class TinyMCEAllowedButtonsConfigurator(object):
 
         # Fallback
         return DEFAULT_TINYMCE_ALLOWED_BUTTONS
+
+
+def get_creator_fullname(obj):
+    creator = obj.Creator()
+    pas_tool = getToolByName(obj, 'acl_users')
+    user = pas_tool.getUserById(creator)
+    if not user:
+        return creator
+    fullname = user.getProperty('fullname', creator)
+    if fullname:
+        return fullname
+    return creator


### PR DESCRIPTION
Enable filtering overview of workspaces by creator.
```
Conflicts:
	ftw/workspace/profiles/default/metadata.xml
	ftw/workspace/upgrades/configure.zcml
```


This separate branch is used for ftw.workspace installations, if it's not possible to upgrade to workspace 3.x.

#56 