### PR TITLE
Fix ftw.pdfgenerator import without dependency

### DIFF
--- a/ftw/workspace/configure.zcml
+++ b/ftw/workspace/configure.zcml
@@ -65,6 +65,8 @@
     </configure>
 
     <configure zcml:condition="installed ftw.zipexport">
-        <adapter factory=".zip_export.WorkspaceZipRepresentation" />
+        <configure zcml:condition="installed ftw.pdfgenerator">
+            <adapter factory=".zip_export.WorkspaceZipRepresentation" />
+        </configure>
     </configure>
 </configure>


### PR DESCRIPTION
The ``zip_export`` requires ``ftw.pdfgenerator`` and its representation should only be loaded when ``ftw.zipexport`` AND ``ftw.pdfgenerator`` is installed.