### PR TITLE
Remove includeDependencies (autoinclude)

### DIFF
--- a/ftw/workspace/configure.zcml
+++ b/ftw/workspace/configure.zcml
@@ -7,9 +7,6 @@
     xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="ftw.workspace">
 
-    <!-- Include configuration for dependencies listed in setup.py -->
-    <includeDependencies package="." />
-
     <include package="plone.registry" />
 
     <five:registerPackage package="." initialize=".initialize" />

--- a/ftw/workspace/dependencies.zcml
+++ b/ftw/workspace/dependencies.zcml
@@ -1,4 +1,0 @@
-<configure
-    xmlns="http://namespaces.zope.org/zope">
-    <include package="ftw.tabbedview" />
-</configure>


### PR DESCRIPTION
The includeDependencies directive should no longer be used.

z3c.autoinclude entry points should make the ZCML be loaded, therefore the includeDependencies is not necessary.

Also: removed no longer used `dependencies.zcml`.