### PR TITLE
Fix builders import.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,11 @@ Changelog
 4.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix builders import.
+  Do no longer import the egov.contactdirectory builders from the builders.py.
+  If you want to use the ftw.workspace builders from another project, you don't
+  want to import the egov.contactdirectory builders.
+  [elioschmutz]
 
 
 4.0.0 (2016-08-08)

--- a/ftw/workspace/testing.py
+++ b/ftw/workspace/testing.py
@@ -13,6 +13,7 @@ from plone.testing import z2
 from plone.testing import zca
 from zope.component import getUtility
 from zope.configuration import xmlconfig
+import egov.contactdirectory.tests.builders
 import ftw.meeting.tests.builders
 import ftw.workspace.tests.builders
 

--- a/ftw/workspace/tests/builders.py
+++ b/ftw/workspace/tests/builders.py
@@ -1,6 +1,5 @@
 from ftw.builder import builder_registry
 from ftw.builder.archetypes import ArchetypesBuilder
-import egov.contactdirectory.tests.builders
 
 
 class WorkspaceBuilder(ArchetypesBuilder):


### PR DESCRIPTION
Do no longer import the egov.contactdirectory builders from the builders.py. If you want to use the ftw.workspace builders from another project, you don't want to import the egov.contactdirectory builders.