### PR TITLE
Improve role setting on workspace creation.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 3.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make setting roles on workspace creation more robust. [jone]
 
 
 3.1.1 (2015-06-03)


### PR DESCRIPTION
Make setting roles more robust (regading value type) by using the public interface rather than modifying internal data structures.
This fixes ValueErrors regarding list / tuple concatenation in some situtations.

Also make sure that roles are not set multiple times by using "set" for reducing duplicates.

See also https://github.com/4teamwork/ftw.workspace/pull/86