### PR TITLE
Improve role setting on workspace creation.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,8 @@ Changelog
   This commit skips the html step and generates latex directly from template.
   [lknoepfel]
 
+- Make setting roles on workspace creation more robust. [jone]
+
 
 4.1.1 (2016-08-16)
 ------------------


### PR DESCRIPTION
Make setting roles more robust (regading value type) by using the public interface rather than modifying internal data structures.
This fixes ValueErrors regarding list / tuple concatenation in some situtations.

Also make sure that roles are not set multiple times by using "set" for reducing duplicates.

See also https://github.com/4teamwork/ftw.workspace/pull/85