### PR TITLE
Fix ZIP tests to include root folder.

### DIFF
--- a/ftw/workspace/tests/test_zip_export.py
+++ b/ftw/workspace/tests/test_zip_export.py
@@ -41,7 +41,7 @@ class TestWorkspaceZipExport(TestCase):
         self.assertEquals('application/zip', browser.headers['Content-Type'])
 
         zipfile = ZipFile(StringIO(browser.contents))
-        self.assertEquals(['workspace.pdf', 'participants.xlsx'],
+        self.assertEquals(['workspace.pdf', 'participants.xlsx', '/'],
                           zipfile.namelist())
 
         xlsx = zipfile.read('participants.xlsx')


### PR DESCRIPTION
ftw.zipexport added a feature to include empty folders.
This has the impact that now the root folder is explicitly listed in
the ZIP file, which makes a change of the test necessary.

https://github.com/4teamwork/ftw.zipexport/pull/45