### PR TITLE
Adapter for IFolderCreator used by zipextract

### DIFF
--- a/ftw/workspace/configure.zcml
+++ b/ftw/workspace/configure.zcml
@@ -82,4 +82,10 @@
        <implements interface="ftw.participation.interfaces.IParticipationSupport" />
     </class>
 
+    <configure zcml:condition="installed ftw.zipextract">
+      <adapter factory=".foldercreator.FolderCreatorInWorkspace" />
+
+      <adapter factory=".foldercreator.FolderCreatorInTabbedViewFolder" />
+    </configure>
+
 </configure>

--- a/ftw/workspace/foldercreator.py
+++ b/ftw/workspace/foldercreator.py
@@ -1,0 +1,18 @@
+from ftw.workspace.content.folder import ITabbedViewFolder
+from ftw.workspace.content.workspace import IWorkspace
+from ftw.zipextract.interfaces import IFolderCreator
+from ftw.zipextract.implementations_base import ObjectCreatorBase
+from zope.component import adapts
+from zope.interface import implements
+
+
+class FolderCreatorInWorkspace(ObjectCreatorBase):
+    implements(IFolderCreator)
+    adapts(IWorkspace)
+    portal_type = "TabbedViewFolder"
+
+
+class FolderCreatorInTabbedViewFolder(ObjectCreatorBase):
+    implements(IFolderCreator)
+    adapts(ITabbedViewFolder)
+    portal_type = "TabbedViewFolder"


### PR DESCRIPTION
Implementation of the `IFolderCreator` interface used by `ftw.zipextract` for `workspace` and `TabbedViewFolder`
See: https://github.com/4teamwork/ftw.zipextract/pull/1