### PR TITLE
Exclude owner from assignable users vocabulary.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 4.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Exclude owner from assignable users vocabulary. [mbaechtold]
 
 
 4.2.0 (2016-11-18)

--- a/ftw/workspace/tests/test_assignable_users_vocabulary.py
+++ b/ftw/workspace/tests/test_assignable_users_vocabulary.py
@@ -110,7 +110,7 @@ class TestFtwNotificationIntegration(TestCase):
         self.subfolder.__ac_local_roles_block__ = True
 
         self.assertItemsEqual(
-            self.owner,
+            [],
             self.vocab_factory(self.subfolder).userids)
 
     def test_dont_list_member_of_group_if_acquistion_stopped(self):
@@ -125,7 +125,7 @@ class TestFtwNotificationIntegration(TestCase):
         self.subfolder.__ac_local_roles_block__ = True
 
         self.assertItemsEqual(
-            self.owner,
+            [],
             self.vocab_factory(self.subfolder).userids)
 
     def test_vocab_is_sorted_by_fullname(self):

--- a/ftw/workspace/vocabularies.py
+++ b/ftw/workspace/vocabularies.py
@@ -84,7 +84,7 @@ class AssignableUsersVocabulary(object):
             userroles = portal.acl_users._getLocalRolesForDisplay(context)
             # Use dict's to auto. prevent duplicated entries
             for user, roles, role_type, name in userroles:
-                if role_type == u'user' and name not in users:
+                if role_type == u'user' and name not in users and set(roles) != {'Owner'}:
                     users.add(name)
                 elif role_type == u'group' and user not in groups:
                     groups.add(name)


### PR DESCRIPTION
The main use case concerns the notification feature which uses the assignable users vocabulary. Imagine a member of the workspace creates some content and the user is then removed from the workspace. Calling the notification view on the user's content would still list the user as a possible recipient of the notification because he still is the owner of the content. This is no longer the case with this change.