### PR TITLE
Exclude owner from assignable users vocabulary.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 3.1.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Exclude owner from assignable users vocabulary. [mbaechtold]
 
 
 3.1.3 (2016-11-21)

--- a/ftw/workspace/tests/assignable_users_vocab.txt
+++ b/ftw/workspace/tests/assignable_users_vocab.txt
@@ -94,4 +94,4 @@ Stop acquisition - test group members
 
 the results should be sortetd on fullname
     >>> [aa.token for aa in factory(portal.f2)]
-    ['test_user_1_', 'member2', 'member3', 'member1']
+    ['member2', 'member3', 'member1']

--- a/ftw/workspace/tests/test_zip_export.py
+++ b/ftw/workspace/tests/test_zip_export.py
@@ -41,7 +41,7 @@ class TestWorkspaceZipExport(TestCase):
         self.assertEquals('application/zip', browser.headers['Content-Type'])
 
         zipfile = ZipFile(StringIO(browser.contents))
-        self.assertEquals(['workspace.pdf', 'participants.xlsx'],
+        self.assertEquals(['workspace.pdf', 'participants.xlsx', '/'],
                           zipfile.namelist())
 
         xlsx = zipfile.read('participants.xlsx')

--- a/ftw/workspace/vocabularies.py
+++ b/ftw/workspace/vocabularies.py
@@ -84,7 +84,7 @@ class AssignableUsersVocabulary(object):
             userroles = portal.acl_users._getLocalRolesForDisplay(context)
             # Use dict's to auto. prevent duplicated entries
             for user, roles, role_type, name in userroles:
-                if role_type == u'user' and name not in users:
+                if role_type == u'user' and name not in users and set(roles) != {'Owner'}:
                     users.add(name)
                 elif role_type == u'group' and user not in groups:
                     groups.add(name)


### PR DESCRIPTION
This is a backport of https://github.com/4teamwork/ftw.workspace/pull/90/. 

At the same time, a backport of https://github.com/4teamwork/ftw.workspace/pull/88 is included in order to fix tests related to the zip export.
  