### PR TITLE
Add FactoryTypeDecider for Workspace and TabbedViewFolder

### DIFF
--- a/ftw/workspace/configure.zcml
+++ b/ftw/workspace/configure.zcml
@@ -77,6 +77,11 @@
         </configure>
     </configure>
 
+    <configure zcml:condition="installed ftw.zipextract">
+        <adapter factory=".zip_extract.WorkspaceFactoryTypeDecider" />
+        <adapter factory=".zip_extract.TabbedViewFolderFactoryTypeDecider" />
+    </configure>
+
     <!-- Enable participation support for Workspace -->
     <class class="ftw.workspace.content.workspace.Workspace">
        <implements interface="ftw.participation.interfaces.IParticipationSupport" />

--- a/ftw/workspace/zip_extract.py
+++ b/ftw/workspace/zip_extract.py
@@ -1,0 +1,17 @@
+from ftw.workspace.content.folder import ITabbedViewFolder
+from ftw.workspace.content.workspace import IWorkspace
+from ftw.zipextract.factory_type_decider import DefaultFactoryTypeDecider
+from zope.component import adapter
+from zope.interface import Interface
+
+
+@adapter(IWorkspace, Interface)
+class WorkspaceFactoryTypeDecider(DefaultFactoryTypeDecider):
+
+    folder_type = "TabbedViewFolder"
+
+
+@adapter(ITabbedViewFolder, Interface)
+class TabbedViewFolderFactoryTypeDecider(DefaultFactoryTypeDecider):
+
+    folder_type = "TabbedViewFolder"


### PR DESCRIPTION
Implementation of the `IFactoryTypeDecider` interface used by `ftw.zipextract` for `workspace` and `TabbedViewFolder`
See: https://github.com/4teamwork/ftw.zipextract/pull/1