### PR TITLE
Fix buildout.

### DIFF
--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -4,3 +4,8 @@ extends =
     sources.cfg
 
 package-name = ftw.workspace
+
+
+[versions]
+# collective.geo.openlayers >= 4.0 is for Plone 5.
+collective.geo.openlayers = 3.2b1


### PR DESCRIPTION
Closes https://github.com/4teamwork/ftw.workspace/issues/94

We need to pin "collective.geo.openlayers" to the 3.x branch because the 4.x branch is for Plone 5.