### PR TITLE
Fix tests by adding ftw.calendar version constraint.

### DIFF
--- a/ftw/workspace/tests/test_add_meetings.py
+++ b/ftw/workspace/tests/test_add_meetings.py
@@ -7,7 +7,7 @@ from plone.app.testing import login
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
-from unittest2 import TestCase
+from unittest import TestCase
 
 
 class TestFtwMeetingIntegration(TestCase):

--- a/ftw/workspace/tests/test_assignable_users_vocabulary.py
+++ b/ftw/workspace/tests/test_assignable_users_vocabulary.py
@@ -8,7 +8,7 @@ from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
 from plone.uuid.interfaces import IUUID
 from Products.CMFPlone.interfaces.factory import IFactoryTool
-from unittest2 import TestCase
+from unittest import TestCase
 from zope.component import getUtility
 from zope.interface import alsoProvides
 from zope.schema.interfaces import IVocabularyFactory

--- a/ftw/workspace/tests/test_auto_roles.py
+++ b/ftw/workspace/tests/test_auto_roles.py
@@ -6,7 +6,7 @@ from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import login
 from plone.app.testing import setRoles
 from plone.registry.interfaces import IRegistry
-from unittest2 import TestCase
+from unittest import TestCase
 from zope.component import getUtility
 
 

--- a/ftw/workspace/tests/test_document_preview.py
+++ b/ftw/workspace/tests/test_document_preview.py
@@ -7,7 +7,7 @@ from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
 from pyquery import PyQuery
-from unittest2 import TestCase
+from unittest import TestCase
 from zope.component import queryMultiAdapter
 
 

--- a/ftw/workspace/tests/test_id_generator.py
+++ b/ftw/workspace/tests/test_id_generator.py
@@ -6,7 +6,7 @@ from plone.app.testing import login
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
-from unittest2 import TestCase
+from unittest import TestCase
 
 
 class TestQuickUploadIdGenerator(TestCase):

--- a/ftw/workspace/tests/test_move_items.py
+++ b/ftw/workspace/tests/test_move_items.py
@@ -5,7 +5,7 @@ from ftw.workspace.testing import FTW_WORKSPACE_FUNCTIONAL_TESTING
 from plone.app.testing import setRoles
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import TEST_USER_ID
-from unittest2 import TestCase
+from unittest import TestCase
 
 
 class TestMoveItems(TestCase):

--- a/ftw/workspace/tests/test_notification.py
+++ b/ftw/workspace/tests/test_notification.py
@@ -7,7 +7,7 @@ from plone.app.testing import login
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
-from unittest2 import TestCase
+from unittest import TestCase
 
 
 class TestFtwNotificationIntegration(TestCase):

--- a/ftw/workspace/tests/test_overview.py
+++ b/ftw/workspace/tests/test_overview.py
@@ -11,7 +11,7 @@ from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
 from plone.testing.z2 import Browser
 from pyquery import PyQuery as pq
-from unittest2 import TestCase
+from unittest import TestCase
 
 
 class TestOverviewTab(TestCase):

--- a/ftw/workspace/tests/test_participation.py
+++ b/ftw/workspace/tests/test_participation.py
@@ -7,7 +7,7 @@ from plone.app.testing import login
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
-from unittest2 import TestCase
+from unittest import TestCase
 
 
 class TestFtwParticipationIntegration(TestCase):

--- a/ftw/workspace/tests/test_preview.py
+++ b/ftw/workspace/tests/test_preview.py
@@ -7,7 +7,7 @@ from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
 from pyquery import PyQuery
-from unittest2 import TestCase
+from unittest import TestCase
 from zope.component import queryMultiAdapter
 import os
 

--- a/ftw/workspace/tests/test_subllisting.py
+++ b/ftw/workspace/tests/test_subllisting.py
@@ -7,7 +7,7 @@ from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
 from plone.registry.interfaces import IRegistry
 from pyquery import PyQuery
-from unittest2 import TestCase
+from unittest import TestCase
 from zope.component import getUtility
 from Products.CMFCore.utils import getToolByName
 

--- a/ftw/workspace/tests/test_workspace.py
+++ b/ftw/workspace/tests/test_workspace.py
@@ -5,7 +5,7 @@ from ftw.workspace.testing import FTW_WORKSPACE_INTEGRATION_TESTING
 from plone.app.testing import login
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
-from unittest2 import TestCase
+from unittest import TestCase
 
 
 class TestWorkspace(TestCase):

--- a/ftw/workspace/tests/test_workspace_example_workflow.py
+++ b/ftw/workspace/tests/test_workspace_example_workflow.py
@@ -7,7 +7,7 @@ from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.testing.z2 import Browser
 from Products.CMFCore.utils import getToolByName
-from unittest2 import TestCase
+from unittest import TestCase
 from zExceptions import Unauthorized
 import transaction
 

--- a/ftw/workspace/tests/test_zip_export.py
+++ b/ftw/workspace/tests/test_zip_export.py
@@ -7,7 +7,7 @@ from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from Products.CMFCore.utils import getToolByName
 from StringIO import StringIO
-from unittest2 import TestCase
+from unittest import TestCase
 from xlrd import open_workbook
 from zipfile import ZipFile
 import transaction

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -9,3 +9,7 @@ package-name = ftw.workspace
 [versions]
 # collective.geo.openlayers >= 4.0 is for Plone 5.
 collective.geo.openlayers = 3.2b1
+
+# Because of https://github.com/4teamwork/ftw.meeting/blob/master/setup.py#L30
+# We need to pin it in buildout because there are other (earlier) dependencies than ftw.meeting
+ftw.calendar = >= 2.1.0, <3


### PR DESCRIPTION
ftw.workspace depends on ftw.meeting, which depends on ftw.calendar with a version constraint. ftw.meeting also depends directly on ftw.calendar without a version constraint. Since buildout does not have an intelligent dependency resolution this can lead to the problem that ftw.calendar was already picked in an incompatible version.

In order to fix that, we must provide a version pinning on buildout level.

Also fixes unittest imports.

Fixes https://github.com/4teamwork/ogb/issues/122